### PR TITLE
Рефакторинг CommandLineArgumentsParser

### DIFF
--- a/src/main/java/newbilius/GamesRevival/CommandLineArgumentsParser/CommandLineArgumentsParserResult.java
+++ b/src/main/java/newbilius/GamesRevival/CommandLineArgumentsParser/CommandLineArgumentsParserResult.java
@@ -2,10 +2,12 @@ package newbilius.GamesRevival.CommandLineArgumentsParser;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class CommandLineArgumentsParserResult {
-    private HashMap<String, String> options = new HashMap<>();
-    private ArrayList<String> errors = new ArrayList<>();
+    private Map<String, String> options = new HashMap<>();
+    private List<String> errors = new ArrayList<>();
 
     public boolean haveError() {
         return !errors.isEmpty();
@@ -32,9 +34,8 @@ public class CommandLineArgumentsParserResult {
     }
 
     public boolean getBoolean(CMDParserOption option, boolean defaultValue) {
-        if (options.containsKey(option.param))
-            return Boolean.parseBoolean(options.get(option.param));
-        return defaultValue;
+        String value;
+        return (value = options.get(option.param)) != null ? Boolean.parseBoolean(value) : defaultValue;
     }
 
     public String getString(CMDParserOption option, String defaultValue) {
@@ -42,8 +43,7 @@ public class CommandLineArgumentsParserResult {
     }
 
     public int getInt(CMDParserOption option, int defaultValue) {
-        if (options.containsKey(option.param))
-            return Integer.parseInt(options.get(option.param));
-        return defaultValue;
+        String value;
+        return (value = options.get(option.param)) != null ? Integer.parseInt(value) : defaultValue;
     }
 }


### PR DESCRIPTION
Привет!

В CommandLineArgumentsParser нашел несколько проблем:
- Для сравнения строк без учета регистра, используется String.equalsIgnoreCase. Такой вариант быстрее по производительности и расходует меньше памяти.
- Проблема с проверке "s.contains("-h")" в функции exitIfOnlyHelpParam. Например, если добавить команду в опции "hurry" (пусть будет типа быстрой работы приложения :) ), то она мне всегда будет выводить справку. Contains проверяет на вхождение текста.
- Проблема в функции exitIfOnlyHelpParam при запуске с пустым массивом. Например, если я создам CommandLineArgumentsParser в котором будут все необязательные параметры, то я не смогу запустить программу без параметров (будет выводиться все время справка)
- В блоке "command.withArgs" есть потенциальная ошибка на java.lang.ArrayIndexOutOfBoundsException. Здесь идет проверка на длину массива, а потом все равно идет обращения за пределы массива(((
- Использование containsKey и get в хеш-мапе плох, потому что он два раза посчитает хеш и два раза пройдется по хеш-таблице. Достаточно просто взять значение в методе get и проверить его на null (то есть работает в два раза быстрее).
- Есть еще моменты, но там уже мелочи.

PS:
- а почему не используется стандартная библиотека, например https://commons.apache.org/proper/commons-cli/
- а почему параметры регистро-независимые? Обычно же они как раз регистро-зависимые. Так например встречается параметры "-v" (version) и "-V" (verbose)