### PR TITLE
поправлена попытка escape текста

### DIFF
--- a/src/main/java/newbilius/GamesRevival/HTML/PortScreensHTMLGenerator.java
+++ b/src/main/java/newbilius/GamesRevival/HTML/PortScreensHTMLGenerator.java
@@ -6,6 +6,8 @@ import newbilius.GamesRevival.GeneratorsInfrastructure.RelativePathHelper;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static com.google.common.html.HtmlEscapers.htmlEscaper;
+
 public class PortScreensHTMLGenerator {
 
     public static String getImageUrl(Port port, String imagePathFromPort) {
@@ -17,7 +19,7 @@ public class PortScreensHTMLGenerator {
         var imageUrl = getImageUrl(port, imagePath);
         return String.format("<a data-title='%s' data-toggle='lightbox' data-gallery='example-gallery' target=_new href='%s'>" +
                         "<img src='%s' style='max-width:300px;margin:4px;' class='img-thumbnail img-fluid'></a>",
-                port.Title.replace("'", "\'"),
+                htmlEscaper().escape(port.Title),
                 imageUrl,
                 imageUrl
         );


### PR DESCRIPTION
Код `port.Title.replace("'", "\'")` равнозначен `port.Title.replace("'", "'")`. То есть
`port.Title.replace("'", "\'").equals(port.Title)` будет всегда возвращать `true`. Скорее всего забыли удвоить слеш, то есть написать `"\\'"`. Но в предлагаемой реализации использовал `htmlEscaper` от гугла (библиотека guava. Используется в org.reflections), потому что визуально в коде становится понятней, что используется escape для заголовка